### PR TITLE
Fix nanosleep test

### DIFF
--- a/assignments/mini-libc/tests/process/Makefile
+++ b/assignments/mini-libc/tests/process/Makefile
@@ -1,4 +1,4 @@
-LIBC_PATH ?= ../../../libc
+LIBC_PATH ?= ../../libc
 CPPFLAGS = -nostdinc -I. -I$(LIBC_PATH)/include
 CFLAGS = -Wall -Wextra -fno-PIC -fno-stack-protector -fno-builtin
 LDFLAGS = -nostdlib -no-pie -L$(LIBC_PATH)

--- a/assignments/mini-libc/tests/process/nanosleep.c
+++ b/assignments/mini-libc/tests/process/nanosleep.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
 #include <time.h>
+#include <stddef.h>
 
 int main(void)
 {
@@ -10,4 +11,3 @@ int main(void)
 
 	return 0;
 }
-


### PR DESCRIPTION
The Makefile from the nanosleep folder has the wrong path towards the include folder in libc.
Also, nanosleep.c should include stddef.h for NULL usage